### PR TITLE
chore: add Frappe maintenance workflow

### DIFF
--- a/.github/workflows/modernize-frappe.yml
+++ b/.github/workflows/modernize-frappe.yml
@@ -1,0 +1,12 @@
+name: Modernize Frappe Packaging
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  modernize:
+    uses: Aakvatech-Limited/frappe-maintenance/.github/workflows/modernize-frappe-reusable.yml@main


### PR DESCRIPTION
Adds the organization-managed Frappe packaging modernization workflow. It is manually triggered and opens modernization changes as a PR.